### PR TITLE
Fix issue 12 original repo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,9 @@ resource "tls_private_key" "ca" {
   algorithm = "RSA"
   rsa_bits  = 2048
 }
-
+locals {
+  associated_subnets_map = { for i, subnet_id in var.associated_subnets : "subnet${i + 1}" => subnet_id }
+}
 resource "tls_self_signed_cert" "ca" {
   private_key_pem = tls_private_key.ca.private_key_pem
 
@@ -134,7 +136,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_ec2_client_vpn_network_association" "this" {
-  for_each               = toset(var.associated_subnets)
+  for_each               = local.associated_subnets_map
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.this.id
   subnet_id              = each.value
 


### PR DESCRIPTION
This patch enables the module to be used in conjunction with subnet creation, where the subnets will only be known after creation.  
# example usage
```
module "client-vpn-federated-authentication" {
  source = "github.com/elastic-infra/terraform-aws-client-vpn-federated-authentication"
  name                   = "${var.vpn_name}-vpn"
  description            = "${var.vpn_name}-vpn"
  split_tunnel_enabled   = true
  self_service_portal    = var.selfservice
  domain_name            = var.vpn_domain
  authorization_rules    = [
  {
    name                 = "access_group"
    access_group_id      = null
    authorize_all_groups = true
    description          = "allow access to all associated subnets"
    target_network_cidr  = "0.0.0.0/0"
  }]
  saml_metadata_document = file("../resources/vpn_metadata.xml")
  client_cidr_block      = aws_vpc_ipam_pool_cidr_allocation.client_vpn_cidr.cidr
  vpc_id                 = aws_vpc.one.id
### specifically something like this was previously not working:
  associated_subnets     = [aws_subnet.main_subnet.id,data.aws_subnet.selected.id]
  tags                   = merge(tomap({
    Name = "${var.vpn_name}-vpn" 
  }),local.global_tags)
}